### PR TITLE
close the path?

### DIFF
--- a/js/circles.js
+++ b/js/circles.js
@@ -12,7 +12,7 @@ function prepareCirclePaths(categories, countyCentroids) {
       var radius = scaleCircles(d[[cat]]);
       var path = 'M' + (projectX([d.lon, d.lat]) - radius) + ' ' + projectY([d.lon, d.lat]) +
         ' a ' + radius + ' ' + radius +
-        ' 0 1 1 0 0.01';
+        ' 0 1 1 0 0.01z';
       pathArray.push(path);
     });
   


### PR DESCRIPTION
I wasn't able to reproduce this problem on any of the mac browsers. I am guessing it is something related to this arc not being a complete circle? adding the `z` to each subpath will close the circle polygon. 

Another idea is that maybe the path d attribute is just too long? I didn't think there was a practical limit, but event just breaking the ~3K dots into 3 separate `path`s instead of one may be a lower effort fix if that is the case. 